### PR TITLE
Feat: HTML img태그의 src가 baseurl에 구애받도록 Generator 추가

### DIFF
--- a/_plugins/asset_baseurl_prefix_generator.rb
+++ b/_plugins/asset_baseurl_prefix_generator.rb
@@ -1,0 +1,27 @@
+require 'nokogiri'
+
+module Jekyll
+  class AssetBaseurlPrefixGenerator < Generator
+    def generate(site)
+      # Check page have html extension
+      site.pages.each do |page|
+        if page.output_ext != ".html"
+          next
+        end
+
+        content = page.output
+        doc = Nokogiri::HTML(content)
+
+        # If relative implementation is required for another tags, add below.
+        doc.css("img").each do |img|
+          src = img["src"]
+          if src.start_with?("/")
+            img["src"] = "{{ site.baseurl }}#{src}"
+          end
+        end
+        
+        page.output = doc.to_html
+      end
+    end
+  end
+end


### PR DESCRIPTION
Markdown 생성 시 <img> 태그의 src를 검사해서 상대경로일 경우 site.baseurl이 앞에 붙을 수 있도록 수정

주의 - **BaseUrl은 /로 끝나면 안 됩니다**. 또한, 페이지에서는 반드시 **/로 시작하는 src를 사용해야만** 상대경로가 적용됩니다.