### PR TITLE
fix: about.markdown 파일의 이미지 URL이 baseurl을 포함하도록 수정

### DIFF
--- a/_pages/about.markdown
+++ b/_pages/about.markdown
@@ -4,7 +4,7 @@ title: About
 permalink: /about/
 ---
 
-<center><img src= '{{ "/assets/img/GDSC Logo chapter.png" }}'></center>
+<center><img src= '{{ "/assets/img/GDSC Logo chapter.png" | relative_url }}'></center>
 
 # GDSC DEU 기술블로그에 오신 것을 환영합니다!
 


### PR DESCRIPTION
Jekyll Liquid Filters를 사용하여 이미지의 상대 경로가 정상적으로 설정되도록 수정함